### PR TITLE
💄 Adds Heading component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "prettier.requireConfig": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This project is using [t3-env](https://github.com/t3-oss/t3-env) for runtime val
 - [vercel](https://vercel.com/)
 - [t3-env](https://github.com/t3-oss/t3-env)
 - [1Password CLI](https://developer.1password.com/docs/cli/secret-references/)
+- [CodeRabbit](https://coderabbit.ai)
 
 ## Authors
 

--- a/components/heading.tsx
+++ b/components/heading.tsx
@@ -30,7 +30,7 @@ export const Heading = <C extends HeadingTags>({
   ...rest
 }: HeadingProps<C>) => {
   const Component = as || "h1";
-  const ariaLevel = (as || "h1").replace("h", "");
+  const ariaLevel = Component.replace("h", "");
 
   return (
     <Component

--- a/components/heading.tsx
+++ b/components/heading.tsx
@@ -1,0 +1,39 @@
+import { VariantProps, cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const headingVariants = cva("scroll-m-20 tracking-tight", {
+  variants: {
+    as: {
+      h1: "text-4xl font-extrabold lg:text-5xl",
+      h2: "border-b pb-2 text-3xl font-semibold first:mt-0",
+      h3: "text-2xl font-semibold",
+      h4: "text-xl font-semibold",
+    },
+  },
+  defaultVariants: {
+    as: "h1",
+  },
+});
+
+type HeadingTags = "h1" | "h2" | "h3" | "h4";
+
+type HeadingProps<C extends HeadingTags> = VariantProps<
+  typeof headingVariants
+> &
+  React.ComponentPropsWithoutRef<C>;
+
+export const Heading = <C extends HeadingTags>({
+  children,
+  as,
+  className,
+  ...rest
+}: HeadingProps<C>) => {
+  const Component = as || "h1";
+
+  return (
+    <Component className={cn(headingVariants({ as, className }))} {...rest}>
+      {children}
+    </Component>
+  );
+};

--- a/components/heading.tsx
+++ b/components/heading.tsx
@@ -30,9 +30,14 @@ export const Heading = <C extends HeadingTags>({
   ...rest
 }: HeadingProps<C>) => {
   const Component = as || "h1";
+  const ariaLevel = (as || "h1").replace("h", "");
 
   return (
-    <Component className={cn(headingVariants({ as, className }))} {...rest}>
+    <Component
+      className={cn(headingVariants({ as, className }))}
+      {...rest}
+      aria-level={ariaLevel}
+    >
       {children}
     </Component>
   );


### PR DESCRIPTION
This commit adds a polymorphic component to render heading tags, h1 -> h4 with specific styles taken from the shadcn/ui typography docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Heading` component for customizable heading elements in React applications.
	- Added a configuration setting for Tailwind CSS to enhance class name recognition.

- **Documentation**
	- Updated the acknowledgments section in `README.md` to include CodeRabbit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->