### PR TITLE
🎨 Removes dynamicParams export

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -115,4 +115,3 @@ export default async function Page({
     </Container>
   );
 }
-export const dynamicParams = false;


### PR DESCRIPTION
this was sending 404s on the articles route to the catchall notFound page instead of the articles notFound page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated routing configuration to disable dynamic parameters for article pages
	- Ensures more predictable page generation and routing behaviour

<!-- end of auto-generated comment: release notes by coderabbit.ai -->