### PR TITLE
chore(config): rename .env to .env.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you're not using the 1Password CLI locally to store environment variables, mo
 
 ```json
 {
-  "dev": "op run --env-file=.env -- next dev"
+  "dev": "op run --env-file=.env.local -- next dev"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"dev": "next dev",
-		"dev:email": "dotenv -e .env -- email dev",
+		"dev:email": "dotenv -e .env.local -- email dev",
 		"build": "next build && pnpm run sitemap:generate",
 		"sitemap:generate": "dotenv -c -- tsx ./lib/sitemap-index.ts",
 		"start": "next start",


### PR DESCRIPTION
## Summary

- Rename `.env` to `.env.local` for consistency with Next.js conventions
- Update `dev:email` script in package.json to reference `.env.local`
- Update README 1Password CLI example to use `.env.local`

## Test plan

- [ ] Verify `pnpm run dev:email` works with `.env.local`
- [ ] Confirm Next.js dev server loads environment variables correctly