### PR TITLE
feat(content): add Human+ co-founder role to resume

### DIFF
--- a/content/data/roles.ts
+++ b/content/data/roles.ts
@@ -30,6 +30,23 @@ export const ROLES: Array<Role> = [
 		href: "https://halobase.com",
 	},
 	{
+		company: "Human+",
+		title: "Co-Founder",
+		logoDetails: {
+			src: "human_plus",
+			pixelWidth: "20px",
+			imageWidth: 20,
+			imageHeight: 20,
+			className: "h-5 w-5 rounded-full",
+		},
+		start: "2025",
+		end: {
+			label: "Present",
+			dateTime: new Date().getFullYear().toString(),
+		},
+		href: "https://human.plus",
+	},
+	{
 		company: "Juro",
 		title: "Senior Software Engineer",
 		logoDetails: {


### PR DESCRIPTION
## Summary
- Add new Human+ co-founder role to the resume/roles data
- Includes logo configuration and link to human.plus

## Test plan
- [ ] Verify the new role appears correctly on the resume page
- [ ] Confirm logo displays properly
- [ ] Check link to human.plus works